### PR TITLE
User can provide getContext implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ AP.configure({
 ```
 
 When called, any method that is not implemented will call the `notImplementedAction` method with the method name and all the arguments.
-Using the above configuration, calling `AP.context.getContext('a', 'b')` will call `console.log('AP.context.getContext', 'a', 'b')`.
+Using the above configuration, calling `AP.resize('a', 'b')` will call `console.log('AP.resize', 'a', 'b')`.
 It is possible to have more advanced behaviors:
 
 ```javascript
@@ -331,10 +331,13 @@ No error will be raised, but nothing will happen since the components will not e
 }
 ```
 
+## Methods that needs a provided implementation
+
+- `AP.context.getContext`: Due to how this method natively work. We can't provide a defaut implementation, so this library will allow you to provide your custom implemntation instead.
+
 ## Not implemented methods
 
 Fake AP is still missing a lot of methods from the actual AP:
-- `AP.context.getContext`
 - `AP.cookie`
 - `AP.dialog`:
   - `getButton`

--- a/README.md
+++ b/README.md
@@ -97,18 +97,19 @@ AP.configure({
 
 Here is a list of all available configuration (refer to their own section for details):
 
-| Configuration                | Default value       | Description                                                   |
-| ---------------------------- | ------------------- | ------------------------------------------------------------- |
-| `clientKey`                  | `null`              | The client key for `AP.context.getToken`                      |
-| `sharedSecret`               | `null`              | The shared secret for `AP.context.getToken`                   |
-| `userId`                     | `null`              | The user ID for `AP.context.getToken`                         |
-| `dialogUrls`                 | `{}`                | URLs to call when using `AP.dialog.create`                    |
-| `locale`                     | `en_US`             | The user locale for `AP.user.getLocale`                       |
-| `requestAdapter`             | `RequestAdapter`    | The request adapter for `AP.request`                          |
-| `notImplementedAction`       | `() => {}`          | The method called when using a method that is not implemented |
-| `missingConfigurationAction` | `throw new Error()` | The method called when a configuration is missing             |
-| `mountDialogs`               | `true`              | `false` to prevent mounting the React component for dialogs   |
-| `mountFlags`                 | `true`              | `false` to prevent mounting the React component for flags     |
+| Configuration                | Default value       | Description                                                                  |
+| ---------------------------- | ------------------- | -----------------------------------------------------------------------------|
+| `clientKey`                  | `null`              | The client key for `AP.context.getToken`                                     |
+| `sharedSecret`               | `null`              | The shared secret for `AP.context.getToken`                                  |
+| `userId`                     | `null`              | The user ID for `AP.context.getToken`                                        |
+| `dialogUrls`                 | `{}`                | URLs to call when using `AP.dialog.create`                                   |
+| `locale`                     | `en_US`             | The user locale for `AP.user.getLocale`                                      |
+| `requestAdapter`             | `RequestAdapter`    | The request adapter for `AP.request`                                         |
+| `notImplementedAction`       | `() => {}`          | The method called when using a method that is not implemented                |
+| `missingConfigurationAction` | `throw new Error()` | The method called when a configuration is missing                            |
+| `mountDialogs`               | `true`              | `false` to prevent mounting the React component for dialogs                  |
+| `mountFlags`                 | `true`              | `false` to prevent mounting the React component for flags                    |
+| `getContextAction`           | `() => {}`          | The function that will be called when calling `AP.context.getContext`        |
 
 **Note:** when using `AP.configure`, all previous configuration is kept, only conflicting configuration is replaced. All new configuration is added.
 
@@ -333,7 +334,7 @@ No error will be raised, but nothing will happen since the components will not e
 
 ## Methods that needs a provided implementation
 
-- `AP.context.getContext`: Due to how this method natively work. We can't provide a defaut implementation, so this library will allow you to provide your custom implemntation instead.
+- `AP.context.getContext`: Due to how this method natively work. We can't provide a defaut behaviour, so this library will allow you to provide your custom implementation instead.
 
 ## Not implemented methods
 

--- a/src/config.js
+++ b/src/config.js
@@ -18,6 +18,10 @@ class Config {
       this.requestAdapter = config.requestAdapter
     }
 
+    if (typeof config.getContextAction === 'function') {
+      this.getContextAction = config.getContextAction
+    }
+
     this.clientKey = config.clientKey ?? this.clientKey
     this.sharedSecret = config.sharedSecret ?? this.sharedSecret
     this.userId = config.userId ?? this.userId
@@ -32,8 +36,11 @@ class Config {
     this.missingConfiguration = (method, configuration) => {
       throw new Error(`Missing configuration for ${method}: ${configuration}`)
     }
+    this.getContextAction = () => {}
 
-    this.requestAdapter = new RequestAdapter((...args) => this.notImplemented('AP.request', ...args))
+    this.requestAdapter = new RequestAdapter((...args) =>
+      this.notImplemented('AP.request', ...args)
+    )
 
     this.clientKey = null
     this.sharedSecret = null

--- a/src/modules/context.js
+++ b/src/modules/context.js
@@ -33,7 +33,7 @@ class Context {
   }
 
   getContext = async (...args) => {
-    return config.notImplemented('AP.context.getContext', ...args)
+    return config.getContextAction(...args)
   }
 }
 

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -42,12 +42,14 @@ describe('default configuration', () => {
 describe('setConfig', () => {
   const notImplementedAction = jest.fn()
   const missingConfigurationAction = jest.fn()
+  const getContextAction = jest.fn()
   const requestAdapter = new RequestAdapter(notImplementedAction)
 
   beforeEach(() => {
     config.setConfig({
       notImplementedAction,
       missingConfigurationAction,
+      getContextAction,
       requestAdapter,
       clientKey: 'key',
       sharedSecret: 'secret',
@@ -62,6 +64,7 @@ describe('setConfig', () => {
 
     notImplementedAction.mockClear()
     missingConfigurationAction.mockClear()
+    getContextAction.mockClear()
   })
 
   describe('when a not implemented action is provided', () => {
@@ -84,6 +87,7 @@ describe('setConfig', () => {
       it('does not change other options', () => {
         expect(config.missingConfiguration).toBe(missingConfigurationAction)
         expect(config.requestAdapter).toBe(requestAdapter)
+        expect(config.getContextAction).toBe(getContextAction)
         expect(config.clientKey).toEqual('key')
         expect(config.sharedSecret).toEqual('secret')
         expect(config.userId).toEqual('user')
@@ -110,6 +114,7 @@ describe('setConfig', () => {
       it('does not change other options', () => {
         expect(config.missingConfiguration).toBe(missingConfigurationAction)
         expect(config.requestAdapter).toBe(requestAdapter)
+        expect(config.getContextAction).toBe(getContextAction)
         expect(config.clientKey).toEqual('key')
         expect(config.sharedSecret).toEqual('secret')
         expect(config.userId).toEqual('user')
@@ -141,6 +146,7 @@ describe('setConfig', () => {
       it('does not change other options', () => {
         expect(config.notImplemented).toBe(notImplementedAction)
         expect(config.requestAdapter).toBe(requestAdapter)
+        expect(config.getContextAction).toBe(getContextAction)
         expect(config.clientKey).toEqual('key')
         expect(config.sharedSecret).toEqual('secret')
         expect(config.userId).toEqual('user')
@@ -167,6 +173,7 @@ describe('setConfig', () => {
       it('does not change other options', () => {
         expect(config.notImplemented).toBe(notImplementedAction)
         expect(config.requestAdapter).toBe(requestAdapter)
+        expect(config.getContextAction).toBe(getContextAction)
         expect(config.clientKey).toEqual('key')
         expect(config.sharedSecret).toEqual('secret')
         expect(config.userId).toEqual('user')
@@ -193,6 +200,7 @@ describe('setConfig', () => {
       it('does not change other options', () => {
         expect(config.notImplemented).toBe(notImplementedAction)
         expect(config.missingConfiguration).toBe(missingConfigurationAction)
+        expect(config.getContextAction).toBe(getContextAction)
         expect(config.clientKey).toEqual('key')
         expect(config.sharedSecret).toEqual('secret')
         expect(config.userId).toEqual('user')
@@ -217,6 +225,59 @@ describe('setConfig', () => {
       it('does not change other options', () => {
         expect(config.notImplemented).toBe(notImplementedAction)
         expect(config.missingConfiguration).toBe(missingConfigurationAction)
+        expect(config.getContextAction).toBe(getContextAction)
+        expect(config.clientKey).toEqual('key')
+        expect(config.sharedSecret).toEqual('secret')
+        expect(config.userId).toEqual('user')
+        expect(config.dialogUrls).toEqual({ dialog: 'url' })
+        expect(config.locale).toEqual('en_US')
+        expect(config.mountDialogs).toEqual(false)
+        expect(config.mountFlags).toEqual(false)
+      })
+    })
+  })
+
+  describe('when a getContextAction is provided', () => {
+    describe('when the getContextAction has the correct type', () => {
+      const newGetContextAction = jest.fn()
+
+      beforeEach(() => {
+        config.setConfig({ getContextAction: newGetContextAction })
+      })
+
+      it('sets the getContextAction to the provided action', () => {
+        expect(config.getContextAction).toBe(newGetContextAction)
+      })
+
+      it('does not change other options', () => {
+        expect(config.notImplemented).toBe(notImplementedAction)
+        expect(config.missingConfiguration).toBe(missingConfigurationAction)
+        expect(config.requestAdapter).toBe(requestAdapter)
+        expect(config.clientKey).toEqual('key')
+        expect(config.sharedSecret).toEqual('secret')
+        expect(config.userId).toEqual('user')
+        expect(config.dialogUrls).toEqual({ dialog: 'url' })
+        expect(config.locale).toEqual('en_US')
+        expect(config.mountDialogs).toEqual(false)
+        expect(config.mountFlags).toEqual(false)
+      })
+    })
+
+    describe('when getContextAction does not have the correct type', () => {
+      const newGetContextAction = 'adapter'
+
+      beforeEach(() => {
+        config.setConfig({ getContextAction: newGetContextAction })
+      })
+
+      it('does not set getContextAction', () => {
+        expect(config.getContextAction).toBe(getContextAction)
+      })
+
+      it('does not change other options', () => {
+        expect(config.notImplemented).toBe(notImplementedAction)
+        expect(config.missingConfiguration).toBe(missingConfigurationAction)
+        expect(config.requestAdapter).toBe(requestAdapter)
         expect(config.clientKey).toEqual('key')
         expect(config.sharedSecret).toEqual('secret')
         expect(config.userId).toEqual('user')

--- a/test/fake-ap.spec.js
+++ b/test/fake-ap.spec.js
@@ -194,6 +194,17 @@ describe('context', () => {
       })
     })
   })
+
+  describe('getContext', () => {
+    it('delegates implementation to the configured function', () => {
+      const getContextAction = jest.fn()
+      AP.configure({ getContextAction: getContextAction })
+
+      AP.context.getContext('a', 'b', 'c')
+
+      expect(getContextAction).toHaveBeenCalledWith('a', 'b', 'c')
+    })
+  })
 })
 
 describe('dialog', () => {
@@ -653,7 +664,6 @@ describe('disabling Dialogs and Flags components', () => {
 })
 
 const notImplementedMethods = [
-  'context.getContext',
   'cookie.save',
   'cookie.read',
   'cookie.erase',


### PR DESCRIPTION
As a user of this library
I want to be able to call `AP.context.getContext` with my custom logic
So I can mock my context in any page